### PR TITLE
Merge "mac-os" branch to master and clean up makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+CXX = gcc
+CXXFLAGS = -g -O0
+FC = gfortran
+FFLAGS = -g -O0 -finteger-4-integer-8 -std=legacy
+
+OBJS = spice.o unix.o
+
+all: spice
+
+spice: $(OBJS)
+	$(FC) $(OBJS) -o spice
+
+%.o: %.f
+	$(FC) -c $(FFLAGS) $*.f -o $*.o 
+
+%.o: %.c
+	$(CXX) $(CXXFLAGS) -c $*.c -o $*.o
+
+clean:
+	rm -f $(OBJS) spice
+

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CXX = gcc
-CXXFLAGS = -g -O0
+CC = gcc
+CFLAGS = -g -O0 -Wno-error
 FC = gfortran
 FFLAGS = -g -O0 -finteger-4-integer-8 -std=legacy
 
@@ -14,7 +14,7 @@ spice: $(OBJS)
 	$(FC) -c $(FFLAGS) $*.f -o $*.o 
 
 %.o: %.c
-	$(CXX) $(CXXFLAGS) -c $*.c -o $*.o
+	$(CC) $(CFLAGS) -c $*.c -o $*.o
 
 clean:
 	rm -f $(OBJS) spice

--- a/README
+++ b/README
@@ -1,13 +1,8 @@
-SPICE 2 Hacked for Linux (AMD-64 only)
+Spice 2
 Modifications by Mike Uchima (aka JustBrewIt) - justbrewit@pobox.com - June 9, 2016
 Further Modifications by Tom Russo - January 2020
-
-Build Instructions for Ubuntu 14.04 LTS 64-bit:
-
-1. Make sure you have the gfortran package installed (i.e. "apt-get install
-   gfortran").
-
-2. Run the build script in this directory (i.e. "./build").
+Modified to compile on Mac by Ulrich Steinmann - Feb 2020
+For Testing purposes
 
 News: 
 1/20/20

--- a/build
+++ b/build
@@ -1,4 +1,0 @@
-#!/bin/sh
-#gcc -c unix.c && gfortran -o spice -std=legacy spice.f unix.o
-gcc -g -O0 -c unix.c && gfortran -g -O0 -o spice -finteger-4-integer-8 -std=legacy spice.f unix.o
-

--- a/unix.c
+++ b/unix.c
@@ -369,7 +369,11 @@ static void GrabArgs(int argc, char* argv[], char* envp[])
     // printf("GrabArgs: copied argc/argv to local variables\n");
 }
 
-__attribute__((section(".init_array"))) void (* PtrGrabArgs)(int,char*[],char*[]) = &GrabArgs;
+#ifdef __APPLE__
+    __attribute__((section("__DATA,__mod_init_func"))) void (* PtrGrabArgs)(int,char*[],char*[]) = &GrabArgs;
+#else
+    __attribute__((section(".init_array"))) void (* PtrGrabArgs)(int,char*[],char*[]) = &GrabArgs;
+#endif 
 
 #ifdef MISCTEST
 

--- a/unix.c
+++ b/unix.c
@@ -60,11 +60,11 @@ xdate_( chr )
         month = itoc( buffer->tm_mon + 1 );   /* month is zero based */
         while( *month )
                 *chr++ = *month++;
-        *chr++ = '\/';
+        *chr++ = '/';
         day = itoc( buffer->tm_mday );
         while( *day )
                 *chr++ = *day++;
-        *chr++ = '\/';
+        *chr++ = '/';
         year = itoc( buffer->tm_year );
         while( *year )
                 *chr++ = *year++;
@@ -100,7 +100,7 @@ dblsgl_( cstar16, numwds )
 	float	*cstar8;
 	int	i;
 
-	return;
+	return( 0 );
 	cstar8 = (float *) cstar16;
 	for ( i = 0; i < (*numwds)/4; i++ ) {
 		cstar8[ i ] = cstar16[ 2*i ];
@@ -109,20 +109,19 @@ dblsgl_( cstar16, numwds )
 
 
 #include <stdio.h>
+#include <stdlib.h>
 FILE	*rawfile;  /* pointer to raw file  */
 
-static int xargc;  /* number of arguments in UNIX command */
-static char    **xargv;/* pointer to an array of pointers to
+static int xargc;    /* number of arguments in UNIX command */
+static char **xargv; /* pointer to an array of pointers to
+                        arguments in UNIX command line  */
 
-    /*
+/*
  * Open raw data file.  Return 1 if file is opened,
  *  return 0 if file is not opened
  */
 iopraw_()
 {
-	// extern	int	xargc;	/* number of arguments in UNIX command */
-	// extern	char	**xargv;/* pointer to an array of pointers to
-	//			arguments in UNIX command line  */
 	int	i;
 	char	*filename = NULL;/* name of raw file */
 
@@ -366,7 +365,7 @@ static void GrabArgs(int argc, char* argv[], char* envp[])
 {
     xargc = argc;
     xargv = argv;
-    // printf("GrabArgs: copied argc/argv to local variables\n");
+    /* printf("GrabArgs: copied argc/argv to local variables\n"); */
 }
 
 #ifdef __APPLE__


### PR DESCRIPTION
The mac-os branch of SPICE-2 contains useful commits that are relevant for more than mac-os, and would be good to merge to master.  This PR does that merge.

The Makefile introduced in commit 2532505 used CXX and CXXFLAGS for the C compiler and its flags, which are usually used for the C++ compiler and its flags --- since this project uses no C++ I have changed the makefile to use CC and CFLAGS instead, merely for consistency with common usage.

In addition, I have added "-Wno-error" to the CFLAGS, because at least some versions of some compiler on some system are flagging the many warnings thrown by unix.c as fatal compilation errors.   The "-Wno-error" turns off that behavior and makes them be warnings again.  The warnings thrown are valid, but harmless --- they all warn that functions that return no value have not been declared with a return type, and so are assumed to be of int return type.  Since the functions return no value and nobody tries to use the functions as if they did, this is a harmless warning.  See #6.

I will propose a fix for the warnings themselves in a second PR.