### PR TITLE
Apply changes to remove meaningless warnings

### DIFF
--- a/unix.c
+++ b/unix.c
@@ -1,6 +1,12 @@
 /*
  * SCCSID=unix.c 3/15/83
  */
+#include <stdlib.h>
+#include <sys/times.h>
+
+/* declarations to avoid warnings */
+void mcopy(char*, char*, int);
+void mclear(char*,int);
 
 /*
  * loc_ - return the address of arg
@@ -17,10 +23,10 @@ loc_( arg )
 /*
  * times_ - c routine to call library routine times
  */
-times_( iarg )
+void times_( iarg )
 	int *iarg ;
 {
-	times( iarg );
+  times( (struct tms *)iarg );
 }
 
 
@@ -29,7 +35,7 @@ times_( iarg )
 /*
  * xtime_ - fortran routine for character time
  */
-xtime_( chr )
+void xtime_( chr )
 	char *chr;
 {
 	struct tm	*localtime();
@@ -47,7 +53,7 @@ xtime_( chr )
 /*
  * xdate_ - fortran routine for character date
  */
-xdate_( chr )
+void xdate_( chr )
 	char	*chr;
 {
 	struct	tm	*localtime(),	*buffer;
@@ -92,15 +98,18 @@ itoc( number )
 /*
  * dblsgl - convert a complex double precision array into
  *  a single precision complex array.
+
+ * Note that as written here, this function actually does nothing, it is
+ * provide strictly so that the fortran call in spice.f works
  */
-dblsgl_( cstar16, numwds )
+void dblsgl_( cstar16, numwds )
 	double	*cstar16;
 	int	*numwds;
 {
 	float	*cstar8;
 	int	i;
 
-	return( 0 );
+	return;
 	cstar8 = (float *) cstar16;
 	for ( i = 0; i < (*numwds)/4; i++ ) {
 		cstar8[ i ] = cstar16[ 2*i ];
@@ -109,7 +118,6 @@ dblsgl_( cstar16, numwds )
 
 
 #include <stdio.h>
-#include <stdlib.h>
 FILE	*rawfile;  /* pointer to raw file  */
 
 static int xargc;    /* number of arguments in UNIX command */
@@ -120,7 +128,7 @@ static char **xargv; /* pointer to an array of pointers to
  * Open raw data file.  Return 1 if file is opened,
  *  return 0 if file is not opened
  */
-iopraw_()
+int iopraw_()
 {
 	int	i;
 	char	*filename = NULL;/* name of raw file */
@@ -152,7 +160,7 @@ iopraw_()
 /*
  * Close raw file.
  */
-clsraw_()
+void clsraw_()
 {
 	fclose( rawfile );
 }
@@ -160,7 +168,7 @@ clsraw_()
  * Write into raw file numwds 16 bit words starting
  *  at location data
  */
-fwrite_( data, numwds )
+void fwrite_( data, numwds )
 	char	*data;
 	int	*numwds;
 {
@@ -172,7 +180,7 @@ fwrite_( data, numwds )
 /*
  * Zero, copy and move for vax unix.
  */
-move_( array1, index1, array2, index2, length )
+void move_( array1, index1, array2, index2, length )
 	register char	*array1, *array2;
 	register int	*length;
 	int		*index1, *index2;
@@ -198,7 +206,7 @@ move_( array1, index1, array2, index2, length )
   These should really be named for the data types they zero instead of
   the sizes!
 */
-zero4_( array, length )
+void zero4_( array, length )
 	char		*array;
 	unsigned	*length;
 {
@@ -206,7 +214,7 @@ zero4_( array, length )
 }
 
 
-zero8_( array, length )
+void zero8_( array, length )
 	char		*array;
 	unsigned	*length;
 {
@@ -214,7 +222,7 @@ zero8_( array, length )
 }
 
 
-zero16_( array, length )
+void zero16_( array, length )
 	char		*array;
 	unsigned	*length;
 {
@@ -222,7 +230,7 @@ zero16_( array, length )
 }
 
 
-copy4_( from, to, length )
+void copy4_( from, to, length )
 	char		*from, *to;
 	int		*length;
 {
@@ -230,7 +238,7 @@ copy4_( from, to, length )
 }
 
 
-copy8_( from, to, length )
+void copy8_( from, to, length )
 	char		*from, *to;
 	int		*length;
 {
@@ -238,7 +246,7 @@ copy8_( from, to, length )
 }
 
 
-copy16_( from, to, length )
+void copy16_( from, to, length )
 	char		*from, *to;
 	int		*length;
 {
@@ -258,7 +266,7 @@ copy16_( from, to, length )
 /*
  * mclear - clear memory.
  */
-mclear( data, size )
+void mclear( data, size )
 	char		*data;
 	int		size;
 {
@@ -282,7 +290,7 @@ mclear( data, size )
 /*
  * mcopy - copy memory.
  */
-mcopy( from, to, size )
+void mcopy( from, to, size )
 	char		*from,	*to;
 	int		size;
 {

--- a/unix.c
+++ b/unix.c
@@ -7,13 +7,13 @@
 /* declarations to avoid warnings */
 void mcopy(char*, char*, int);
 void mclear(char*,int);
+char  *itoc( int );
 
 /*
  * loc_ - return the address of arg
  */
 unsigned long
-loc_( arg )
-	long int *arg;
+loc_( long int *arg )
 {
 	return( (unsigned long) arg );
 }
@@ -23,8 +23,7 @@ loc_( arg )
 /*
  * times_ - c routine to call library routine times
  */
-void times_( iarg )
-	int *iarg ;
+void times_( int *iarg )
 {
   times( (struct tms *)iarg );
 }
@@ -35,12 +34,9 @@ void times_( iarg )
 /*
  * xtime_ - fortran routine for character time
  */
-void xtime_( chr )
-	char *chr;
+void xtime_( char *chr )
 {
-	struct tm	*localtime();
-	char		*asctime(),	*character;
-	long		time();
+	char		*character;
 	long		tloc,	scum;
 	int		i;
 
@@ -53,12 +49,10 @@ void xtime_( chr )
 /*
  * xdate_ - fortran routine for character date
  */
-void xdate_( chr )
-	char	*chr;
+void xdate_( char *chr )
 {
-	struct	tm	*localtime(),	*buffer;
-	char		*asctime(),	*month,	*day,	*year,	*itoc();
-	long		time();
+	struct	tm	*buffer;
+	char		*month,	*day,	*year;
 	long		tloc,	scum;
 
         tloc = time( & scum );
@@ -79,8 +73,7 @@ void xdate_( chr )
  * itoc
  */
 char  *
-itoc( number )
-	int	number;
+itoc( int number )
 {
   static char string[3];
 
@@ -102,9 +95,7 @@ itoc( number )
  * Note that as written here, this function actually does nothing, it is
  * provide strictly so that the fortran call in spice.f works
  */
-void dblsgl_( cstar16, numwds )
-	double	*cstar16;
-	int	*numwds;
+void dblsgl_( double *cstar16, int *numwds )
 {
 	float	*cstar8;
 	int	i;
@@ -168,9 +159,7 @@ void clsraw_()
  * Write into raw file numwds 16 bit words starting
  *  at location data
  */
-void fwrite_( data, numwds )
-	char	*data;
-	int	*numwds;
+void fwrite_( char* data, int *numwds )
 {
 	fflush( stderr );
 	fwrite( data, 2, *numwds, rawfile );
@@ -180,10 +169,7 @@ void fwrite_( data, numwds )
 /*
  * Zero, copy and move for vax unix.
  */
-void move_( array1, index1, array2, index2, length )
-	register char	*array1, *array2;
-	register int	*length;
-	int		*index1, *index2;
+void move_( char * array1, int *index1, char *array2, int *index2, int *length )
 {
 	array1 += *index1 - 1;
 	array2 += *index2 - 1;
@@ -206,49 +192,37 @@ void move_( array1, index1, array2, index2, length )
   These should really be named for the data types they zero instead of
   the sizes!
 */
-void zero4_( array, length )
-	char		*array;
-	unsigned	*length;
+void zero4_( char *array, unsigned *length )
 {
 	mclear( array, *length * 8 );
 }
 
 
-void zero8_( array, length )
-	char		*array;
-	unsigned	*length;
+void zero8_( char *array, unsigned *length )
 {
 	mclear( array, *length * 8 );
 }
 
 
-void zero16_( array, length )
-	char		*array;
-	unsigned	*length;
+void zero16_( char *array, unsigned *length )
 {
 	mclear( array, *length * 8 );
 }
 
 
-void copy4_( from, to, length )
-	char		*from, *to;
-	int		*length;
+void copy4_( char *from, char *to, int *length )
 {
 	mcopy( from, to, *length * 8 );
 }
 
 
-void copy8_( from, to, length )
-	char		*from, *to;
-	int		*length;
+void copy8_( char *from, char *to, int *length )
 {
 	mcopy( from, to, *length * 8 );
 }
 
 
-void copy16_( from, to, length )
-	char		*from, *to;
-	int		*length;
+void copy16_( char *from, char *to, int *length )
 {
 	mcopy( from, to, *length * 8 );
 }
@@ -266,9 +240,7 @@ void copy16_( from, to, length )
 /*
  * mclear - clear memory.
  */
-void mclear( data, size )
-	char		*data;
-	int		size;
+void mclear( char *data, int size )
 {
 #ifdef	VAXUNIXASM
 	register int	i = VAXMAXSIZE;
@@ -290,9 +262,7 @@ void mclear( data, size )
 /*
  * mcopy - copy memory.
  */
-void mcopy( from, to, size )
-	char		*from,	*to;
-	int		size;
+void mcopy( char *from, char *to, int size )
 {
 #ifdef	VAXUNIXASM
 	register int		i = VAXMAXSIZE;
@@ -345,9 +315,7 @@ void mcopy( from, to, size )
  * mcmp - compare memory.
  */
 int
-mcmp( from, to, size )
-	char		*from,	*to;
-	int		size;
+mcmp( char *from, char *to, int size )
 {
 #ifdef	VAXUNIXASM
 	register int	i = VAXMAXSIZE;


### PR DESCRIPTION
The code in unix.c defined many functions meant to be called from Fortran that returned no value, or that were meant to be called internally but also returned no value and were used without trying to access any return value.

This meant that all the undeclared functions were presumed to be of type int, which is the old fashioned assumption in early C, and causes no problems in this case.  It is, however, warned of by all modern compilers because it is often a mistake to do that.

Recent versions of gcc have begun treating such warnings as errors and defining that type of usage as "nonconformant" (that is, not in conformance with modern coding best practices).

GH-6 reports compilation failures due to these issues, and the workaround was to use compiler options to turn those particular issues back into warnings.  GH-8 is a pull request that puts those options into Makefile, which is a fine approach, but a better one is to make the unix.c code not throw warnings in the first place.

This commit fixes the code so it no longer throws warnings.

All functions meant to be called from fortran as subroutines (those that return no value and whose names end with "_") have been declared as void.

All functions called internally only by unix.c and which return no value have been declared as void, and prototypes added to the top of the file to prevent warnings about redefining function types that had previously been declared implicitly as int.

Includes of stdlib.h and sys/times.h have been inserted to prevent warnings about implicit declaration of standard system functions "exit" and "times" (respectively).

Correct casting of an integer pointer to a (struct tms *) pointer has been inserted to prevent warnings about incorrect argument type to the "times" system function.

This commit should render GH-8 unnecessary, and should fix GH-6.

Closes GH-6